### PR TITLE
refactor: update IContestRegistrationServices and IContestRegistrationResponse

### DIFF
--- a/koi-war-backend/src/services/IContestRegistrationServices.ts
+++ b/koi-war-backend/src/services/IContestRegistrationServices.ts
@@ -1,9 +1,10 @@
 import { IContestRegistrationResponse } from "../types/contestRegistration";
+import {IRegistration} from "../models/registration.model";
 
 export interface IContestRegistrationServices {
   createContestRegistration(data: any): Promise<any>;
   getContestRegistrationById(id: string): Promise<any>;
   getContestRegistrationByFishId(
     fishId: string
-  ): Promise<IContestRegistrationResponse>;
+  ): Promise<IRegistration & {_id: string}>;
 }

--- a/koi-war-backend/src/services/impl/competitionManagementServices.ts
+++ b/koi-war-backend/src/services/impl/competitionManagementServices.ts
@@ -1,7 +1,7 @@
 import {ICompetitionManagementServices} from "../ICompetitionManagementServices";
 import {IScoreServices} from "../IScoreServices";
 import {IContestRegistrationServices} from "../IContestRegistrationServices";
-import {IContestRegistrationResponse} from "../../types/contestRegistration";
+import {IContestRegistrationResponse, mapContestRegistrationResponse} from "../../types/contestRegistration";
 
 export class CompetitionManagementServices implements ICompetitionManagementServices {
     private scoreServices: IScoreServices;
@@ -23,12 +23,12 @@ export class CompetitionManagementServices implements ICompetitionManagementServ
 
         const contestRegistration = await this.registrationServices.getContestRegistrationByFishId(fishId);
 
-        contestRegistration.score = await this.scoreServices.getScoreByRegistrationId(
-            contestRegistration.id
+        contestRegistration.scores = await this.scoreServices.getScoreByRegistrationId(
+            contestRegistration._id
         );
 
-        return contestRegistration;
-
+        // return contestRegistration;
+        return mapContestRegistrationResponse(contestRegistration);
     }
 
     getContestRegistrationById(id: string): Promise<any> {

--- a/koi-war-backend/src/services/impl/contestRegistrationServices.ts
+++ b/koi-war-backend/src/services/impl/contestRegistrationServices.ts
@@ -1,11 +1,10 @@
 import {IContestRegistrationRepository} from "../../repositories/IContestRegistrationRepository";
-import {mapContestInstanceResponse} from "../../types/contestInstance";
-import {IContestRegistrationResponse} from "../../types/contestRegistration";
 import {IClassificationContestRuleServices} from "../IClassificationContestRuleServices";
 import {IContestInstanceServices} from "../IContestInstanceServices";
 import {IContestRegistrationServices} from "../IContestRegistrationServices";
 import {IContestSubCategoryService} from "../IContestSubCategoryService";
 import {IFishService} from "../IFishService";
+import {IRegistration} from "../../models/registration.model";
 
 export class ContestRegistrationServices
     implements IContestRegistrationServices {
@@ -91,7 +90,7 @@ export class ContestRegistrationServices
 
     async getContestRegistrationByFishId(
         fishId: string
-    ): Promise<IContestRegistrationResponse> {
+    ): Promise<IRegistration & {_id: string}> {
         const contestRegistration =
             await this.contestRegistrationRepository.getContestRegistrationByFishId(
                 fishId
@@ -100,11 +99,6 @@ export class ContestRegistrationServices
             throw new Error("Contest registration not found");
         }
 
-        return {
-            ...mapContestInstanceResponse(contestRegistration),
-            fish: contestRegistration.fish,
-            score: contestRegistration.score,
-            contestSubCategory: contestRegistration.contestSubCategory,
-        };
+        return contestRegistration;
     }
 }

--- a/koi-war-backend/src/types/contestRegistration.ts
+++ b/koi-war-backend/src/types/contestRegistration.ts
@@ -12,7 +12,7 @@ import { IContestSubCategory } from "../models/contestSubCategory.model";
 export interface IContestRegistrationResponse {
   id: string;
   fish: IFishProfileResponse;
-  score: IScoreResponse[];
+  scores: IScoreResponse[];
   contestSubCategory: IContestSubCategoryResponse;
 }
 
@@ -24,7 +24,7 @@ export function mapContestRegistrationResponse(
     fish: mapFishProfileResponse(
       data.fish as IFish & { _id: string; createdAt: Date; updatedAt: Date }
     ),
-    score: data.scores
+    scores: data.scores
       ? (
           data.scores as (IScore & {
             _id: string;


### PR DESCRIPTION
- Update IContestRegistrationServices to include a new interface IRegistration from the models/registration.model file.
- Update IContestRegistrationResponse to change the property name 'score' to 'scores'.
- Remove unnecessary code from ContestRegistrationServices and return the contestRegistration object as is.